### PR TITLE
Make outgoing links be full links so they go where they should

### DIFF
--- a/app/js/lesson_plans.coffee
+++ b/app/js/lesson_plans.coffee
@@ -32,20 +32,20 @@ root.lessons =
   3:
     0:
       startingText: "Search for it.()"
-      answer: "[Search for it.](www.google.com)"
-      renderedAnswer:"<p><a href=\"www.google.com\">Search for it.</a></p>"
+      answer: "[Search for it.](http://www.google.com)"
+      renderedAnswer:"<p><a href=\"http://www.google.com\">Search for it.</a></p>"
     1:
       startingText: "You're really, really going to want to see this."
-      answer: "[You're **really, really** going to want to see this.](www.dailykitten.com)"
-      renderedAnswer: "<p><a href=\"www.dailykitten.com\">You're <strong>really, really</strong> going to want to see this.</a></p>"
+      answer: "[You're **really, really** going to want to see this.](http://www.dailykitten.com)"
+      renderedAnswer: "<p><a href=\"http://www.dailykitten.com\">You're <strong>really, really</strong> going to want to see this.</a></p>"
     2:
       startingText: "The Latest News from the BBC"
-      answer: "#### The Latest News from [the BBC](www.bbc.com/news)"
-      renderedAnswer: "<h4>The Latest News from <a href=\"www.bbc.com/news\">the BBC</a></h4>"
+      answer: "#### The Latest News from [the BBC](http://www.bbc.com/news)"
+      renderedAnswer: "<h4>The Latest News from <a href=\"http://www.bbc.com/news\">the BBC</a></h4>"
     3:
       startingText: "Do you want to [see something fun][]?\n\nWell, do I have [the website for you][another fun place]!"
-      answer: "Do you want to [see something fun][a fun place]?\n\nWell, do I have [the website for you][another fun place]!\n\n[a fun place]: www.zombo.com\n\n[another fun place]: www.stumbleupon.com"
-      renderedAnswer: "<p>Do you want to <a href=\"www.zombo.com\">see something fun</a>?</p>\n<p>Well, do I have <a href=\"www.stumbleupon.com\">the website for you</a>!</p>"
+      answer: "Do you want to [see something fun][a fun place]?\n\nWell, do I have [the website for you][another fun place]!\n\n[a fun place]: http://www.zombo.com\n\n[another fun place]: http://www.stumbleupon.com"
+      renderedAnswer: "<p>Do you want to <a href=\"http://www.zombo.com\">see something fun</a>?</p>\n<p>Well, do I have <a href=\"http://www.stumbleupon.com\">the website for you</a>!</p>"
 
   4:
     0:

--- a/views/lesson3.erb
+++ b/views/lesson3.erb
@@ -1,13 +1,16 @@
 
 <p>We'll now learn how to make links to other web sites on the world wide web.</p>
 
-<p>There are two different link types in Markdown, but both of them render the exact
-  same way. The first link style is called an <em>inline link</em>. To create an inline
-  link, you wrap the link text in brackets ( <code>[ ]</code> ), and then you wrap the link
-  in parenthesis ( <code>( )</code> ). For example, to create a hyperlink to www.github.com, with a link text
-  that says, Visit GitHub!, you'd write this in Markdown: <code>[Visit GitHub!](www.github.com)</code>.</p>
+<p>There are two different link types in Markdown, but both of them
+  render the exact same way. The first link style is called an
+  <em>inline link</em>. To create an inline link, you wrap the link
+  text in brackets ( <code>[ ]</code> ), and then you wrap the link in
+  parenthesis ( <code>( )</code> ). For example, to create a hyperlink
+  to http://www.github.com, with a link text that says, Visit GitHub!,
+  you'd write this in Markdown: <code>[Visit
+  GitHub!](http://www.github.com)</code>.</p>
 
-<p>In the box below, make a link to www.google.com, with some text that says "Search for it."</p>
+<p>In the box below, make a link to http://www.google.com, with some text that says "Search for it."</p>
 <div class="row">
   <div class="span5 scratchpad"></div>
   <span class="help-tooltip icon-question" data-toggle="tooltip" data-original-title="You'll type your answers in the left box; the Markdown result will appear in the right box. When your answer is correct, you'll be taken to the next lesson"></span>
@@ -18,7 +21,7 @@
   <hr>
   <p>Nice work!</p>
   <p>You can add emphasis to link texts, if you like. In the box below, make the
-  phrase "really, really" bold, and have the entire sentence link to www.dailykitten.com.
+  phrase "really, really" bold, and have the entire sentence link to http://www.dailykitten.com.
   You'll want to make sure that the bold phrasing occurs within the link text brackets.</p>
   <div class="row">
     <div class="span5 scratchpad"></div>
@@ -32,7 +35,7 @@
   <p>Although it might make for an awkward experience, you can make links within
   headers, too.</p>
   <p>For this next tutorial, make the text a heading four, and turn the phrase
-  "the BBC" into a link to www.bbc.com/news:</p>
+  "the BBC" into a link to http://www.bbc.com/news:</p>
   <div class="row">
     <div class="span5 scratchpad"></div>
     <div class="span5 renderpad"></div>
@@ -50,8 +53,8 @@
      Here's [yet another link][another-link].
      And now back to [the first link][another place].
 
-     [another place]: www.github.com
-     [another-link]: www.google.com
+     [another place]: http://www.github.com
+     [another-link]: http://www.google.com
   </pre>
   <p>The "references" above are the second set of brackets: <code>[another place]</code> and
     <code>[another-link]</code>. At the bottom of a Markdown document, these brackets are defined
@@ -63,7 +66,7 @@
     the same tag name wrapped in brackets, followed by a colon, followed by the link.</p>
   <p>In the box below, we've started writing out some reference links. You'll
     need to finish them up! Call the first reference tag "a fun place", and make
-    it link to www.zombo.com; make the second link out to www.stumbleupon.com.</p>
+    it link to http://www.zombo.com; make the second link out to http://www.stumbleupon.com.</p>
   <div class="row">
     <div class="span5 scratchpad"></div>
     <div class="span5 renderpad"></div>


### PR DESCRIPTION
The current version makes nice links, but if a user wants to click on them and see them in action, the attempt to link to the destinations within the learn-markup app, which isn't right.
