### PR TITLE
Add link to the Markdown Guide

### DIFF
--- a/conclusion.md
+++ b/conclusion.md
@@ -19,3 +19,4 @@ to explore any number of other Markdown apps and tutorials. Here are just a few:
 * <http://spec.commonmark.org/dingus/>
 * <http://johnmacfarlane.net/babelmark2/faq.html>
 * <http://idratherbewriting.com/2013/06/04/exploring-markdown-in-collaborative-authoring-to-publishing-workflows/>
+* <https://www.markdownguide.org>


### PR DESCRIPTION
I'd like to suggest adding a link in the conclusion to the [Markdown Guide](https://www.markdownguide.org), another [open source](https://github.com/mattcone/markdown-guide) Markdown reference. I think readers might find the site helpful.

Disclosure: I created the Markdown Guide.