### PR TITLE
Fix typos

### DIFF
--- a/lessons/_en/3.html
+++ b/lessons/_en/3.html
@@ -5,12 +5,12 @@ number: 3
 ---
 
 <div class="row">
-<p>We'll now learn how to make links to other web sites on the world wide web.</p>
+<p>We'll now learn how to make links to other web sites on the World Wide Web.</p>
 
 <p>There are two different link types in Markdown, but both of them render the exact
   same way. The first link style is called an <em>inline link</em>. To create an inline
   link, you wrap the link text in brackets ( <code>[ ]</code> ), and then you wrap the link
-  in parenthesis ( <code>( )</code> ). For example, to create a hyperlink to www.github.com, with a link text
+  in parentheses ( <code>( )</code> ). For example, to create a hyperlink to www.github.com, with a link text
   that says, Visit GitHub!, you'd write this in Markdown: <code>[Visit GitHub!](www.github.com)</code>.</p>
 
 <p>In the box below, make a link to www.google.com, with link text that says "Search for it."</p>


### PR DESCRIPTION
I changed "world wide web" to uppercase, as it should be written. I also changed "parenthesis" to "parentheses," since "parenthesis" is singular for one curly bracket, whereas "parentheses" is the plural form for more than one curly bracket and more than one parenthesis is used in the example.