### PR TITLE
Fix Typo

### DIFF
--- a/lessons/_en/4.html
+++ b/lessons/_en/4.html
@@ -14,7 +14,7 @@ number: 4
 
 <p>The first image style is called an <em>inline image link</em>. To create an inline
   image link, enter an exclamation point ( <code>!</code> ), wrap the alt text in brackets ( <code>[ ]</code> ), and then wrap the link
-  in parenthesis ( <code>( )</code> ). (Alt text is a phrase or sentence that describes the
+  in parentheses ( <code>( )</code> ). (Alt text is a phrase or sentence that describes the
   image for the visually impaired.)</p>
 
 <p>For example, to create an inline image link to https://octodex.github.com/images/bannekat.png, with an alt text


### PR DESCRIPTION
I changed "parenthesis" to "parentheses" since more than one parenthesis is used in this example. "Parenthesis" is singular for one curly bracket, whereas "parentheses" is plural for more than one curly bracket.