### PR TITLE
Fix typo

### DIFF
--- a/lessons/_en/6.html
+++ b/lessons/_en/6.html
@@ -65,7 +65,7 @@ numbers.</p>
   <hr>
   <p>Fantastic work!</p>
   <p>You can choose to add italics, bold, or links within lists, as you might expect.
-    In the box below, turn the latin names for the plants into italics.</p>
+    In the box below, turn the Latin names for the plants into italics.</p>
     <div class="col-md-5 scratchpad"></div>
     <div class="col-md-5 renderpad"></div>
   </div>


### PR DESCRIPTION
I changed "latin" to "Latin" since it's a proper noun and proper nouns are capitalized.