### PR TITLE
Fix NL/Dutch homepage and initial markdown code instructions

### DIFF
--- a/lessons/_nl/1.html
+++ b/lessons/_nl/1.html
@@ -8,15 +8,15 @@ number: 1
   <p>
     We beginnen met twee opmaakelementen. <em>Schuin</em>gedrukt en
     <strong>vet</strong>gedrukt. In deze lessenserie zie je soms
-    <code>code in het rood</code>. Doordat Markdown er niet anders uitziet dan
-    'gewone' tekst zie je het verschil niet. Door de code rood te maken zie je
-    direct welke code zorgt voor de opmaak.
+    <code>tekst in het rood</code>. Doordat Markdowncode er niet anders uitziet dan
+    'gewone' tekst zie je het verschil niet. Doordat wij de Markdowncode rood maken zie je
+    direct welke tekst zorgt voor de opmaak.
   </p>
 
   <p>
     Om iets <em>schuingedrukt</em> te maken in Markdown dan gebruik je daarvoor
     het platliggende streepje (<code>_</code> ). Voorbeeld,
-    <code>dit</code> woord wordt <em>schuingedrukt</em>.
+    <code>_dit_</code> woord wordt <em>schuingedrukt</em>.
   </p>
 
   <p>De eerste oefening, maak het woord "niet" schuingedrukt.</p>

--- a/nl/index.md
+++ b/nl/index.md
@@ -3,18 +3,18 @@ layout: default
 locale: nl
 ---
 
-Markdown is een manier om inhoud voor het web te schrijven. Het is geschreven in wat we 'platte tekst' noemen. Tekst zonder opmaak is bevat het gewone alfabet, met een paar bekende symbolen, zoals sterretjes (<code>*</code>) en het aanhalingsteken(<code>'</code>).
+Markdown is een manier om inhoud voor het web te schrijven. Het is geschreven in wat we 'platte tekst' noemen. Platte tekst bevat het reguliere alfabet, met daarbij een paar bekende symbolen, zoals sterretjes (<code>*</code>) en het accent grave (<code>`</code>).
 
-In tegenstelling tot tekstverwerkingsprogramma's, kan tekst die in Markdown is geschreven gemakkelijk worden gedeeld.  Zowel tussen computers, mobiele telefoons en mensen. Het wordt snel de schrijfstandaard voor [academici](http://chronicle.com/blogs/profhacker/markdown-the-syntax-you-probably-already-know/35295), [wetenschappers](http://blogs.plos.org/mfenner/2012/12/13/a-call-for-scholarly-markdown/), [schrijvers(https://lifehacker.com/5943320/what-is-markdown-and-why-is-it-better-for-my-to+do-lists-and-notes) en nog veel meer. Websites zoals [GitHub](https://www.github.com) en [reddit](http://www.reddit.com) gebruiken Markdown om reacties vorm te geven.
+In tegenstelling tot tekstverwerkingsprogramma's, kan tekst die in Markdown is geschreven gemakkelijk worden gedeeld. Zowel tussen computers, mobiele telefoons en mensen. Het wordt snel de schrijfstandaard voor [academici][academics], [wetenschappers][scientists], [schrijvers][writers] en nog veel meer. Websites zoals [GitHub](https://www.github.com) en [reddit](http://www.reddit.com) gebruiken Markdown om reacties vorm te geven.
 
-Tekst opmaken in Markdown heeft een fijne en korte leercurve. Het doet niets speciaals! Het enige waar je controle over hebt, is de weergave van de tekst, zoals dingen vet maken, kopteksten maken en lijsten organiseren. Lettergrote, kleur of lettertype worden niet met Markdown opgemaakt.
+Tekst opmaken in Markdown heeft een fijne en korte leercurve. Het doet niets sierlijks zoals het aanpassen van: lettergrote, kleur of lettertype. Het enige waar je controle over hebt, is de weergave van de tekst, zoals: dingen vet maken, kopteksten maken en lijsten organiseren.
 
 In minder dan 10 minuten kun jij ook Markdown leren! Er zijn  in totaal 7 lessen met daarin een aantal oefeningen.
 
-In elke les krijg je een inleiding tot één Markdown-concept. Vervolgens wordt je gevraagd om met die nieuwe concept verschillende oefeningen te doen.
+In elke les krijg je een inleiding tot één Markdown-concept. Vervolgens wordt je gevraagd om met dit nieuwe concept verschillende oefeningen te doen.
 
-<a class="btn btn btn-lg btn-success" href="{{site.data.tooltips.lesson_1[page.locale].href }}">Ready? Aan de slag!</a>
+<a class="btn btn btn-lg btn-success" href="{{site.data.tooltips.lesson_1[page.locale].href }}">Klaar? Aan de slag!</a>
 
-[universitaires]: http://chronicle.com/blogs/profhacker/markdown-the-syntax-you-probably-already-know/35295
-[scientifiques]: http://blogs.plos.org/mfenner/2012/12/13/a-call-for-scholarly-markdown/
-[rédacteurs]: http://lifehacker.com/5943320/what-is-markdown-and-why-is-it-better-for-my-to+do-lists-and-notes
+[academics]: http://chronicle.com/blogs/profhacker/markdown-the-syntax-you-probably-already-know/35295
+[scientists]: http://blogs.plos.org/mfenner/2012/12/13/a-call-for-scholarly-markdown/
+[writers]: http://lifehacker.com/5943320/what-is-markdown-and-why-is-it-better-for-my-to+do-lists-and-notes


### PR DESCRIPTION
Fixes:
1. some weird (and plain wrong) sentences on the homepage.
2. explanation about how markdown code is shown in the lessons was confusing.


